### PR TITLE
chore: Switch to self-hosted GitHub agents

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updated GitHub workflow files to use self-hosted agents instead of GitHub-hosted runners